### PR TITLE
Added support for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "prism-monokai",
+  "version": "0.0.0",
+  "homepage": "https://github.com/Ahrengot/Monokai-theme-for-Prism.js",
+  "authors": [
+    "Jens Ahrengot Boddum <>"
+  ],
+  "description": "Adds the Soda Monokai theme for Prism.js syntax highlighter",
+  "main": "./styles/syntax-highlighting.css",
+  "dependencies": {
+    "prism": "git@github.com:LeaVerou/prism.git#gh-pages"
+  },
+  "keywords": [
+    "syntax",
+    "highlighter",
+    "Prism.js",
+    "Soda",
+    "Monokai"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
For better install I added bower support, please make a tag with version. Thanks.

See more with:

`bower info prism-monokai`
